### PR TITLE
Patch v0.1.8_alpha

### DIFF
--- a/exportBoard.js
+++ b/exportBoard.js
@@ -26,8 +26,8 @@
 			return;
 		} else {
 			board = {
-				version: 0.0107,
-				title: "Checklist",
+				version: 0.0108,
+				title: $.trim($("#title").html()),
 				lists: [],
 				notes: []
 			};
@@ -37,7 +37,7 @@
 				let n = (/list-(\d+)/g).exec(e.id)[1] * 1;
 
 				let newList = {
-					name: $("#list-" + n + "-name").html(),
+					name: $("#list-" + n + "-name span").html(),
 					items: [],
 					top: e.style.top,
 					left: e.style.left,

--- a/index.html
+++ b/index.html
@@ -15,14 +15,14 @@ Inspired by Tasker and Tasker2, both by Zevan Rosser (https://github.com/ZevanRo
 		<script type="text/javascript" src="css-element-queries-by-marcj/ResizeSensor.js"></script>
         <script type="text/javascript" src="main.js"></script>
         <script type="text/javascript" src="exportBoard.js"></script>
-        <script type="text/javascript" src="importBoard.js"></script>
+		<script type="text/javascript" src="importBoard.js"></script>
 		<script type="text/javascript">
 			let defaultBoard = {
-				version: 0.0107,
+				version: 0.0108,
 				title: "Checklist",
 				lists: [
 					{
-						name: "List 1",
+						name: "List 0",
 						items: [
 							{
 								value: "Task 0",
@@ -69,6 +69,16 @@ Inspired by Tasker and Tasker2, both by Zevan Rosser (https://github.com/ZevanRo
 				window.onbeforeunload = function(){
 					return "Data will be lost if you exit or refresh.";
 				};
+				
+				$(window).resize(function(){
+					$(".list,.note").toArray().forEach(function(e){
+						$(e).css({
+							"left": "min(" + e.style.left + ", calc(100vw - 4px - " + $(e).width() + "px))",
+							"top": "min(" + e.style.top + ", calc(100vh - 4px - " + $(e).height() + "px))"
+						});
+					});
+				});
+				
 				// Add keylistener to title input
 				$("#title-text").on("keypress", function(e){
 					let h1 = $("#title"),
@@ -110,12 +120,12 @@ Inspired by Tasker and Tasker2, both by Zevan Rosser (https://github.com/ZevanRo
 			<svg viewBox="0 0 20 20"><g fill="none" stroke-width="5"><path d="M10 0v20M0 10h20"/></g></svg>
 		</image-src>
 		<div id="container">
-			<span id="version-info">v0.1.7-1_alpha &mdash; D-Doc, 2020</span>
+			<span id="version-info">v0.1.8_alpha &mdash; D-Doc, 2020</span>
 			<span id="toolbar">
 				<span class="file-img" tooltip="Add a new list" onclick="addList()">
 					<svg viewBox="0 0 47.8 56.9"><path d="M37 2v9h9z" stroke-width="4" stroke-linejoin="round"/><path d="M18 2v37h28V11l-9-9z" stroke-width="4" stroke-linejoin="round"/><path d="M31 33l-6-7M41 16L31 33" stroke-width="4" stroke-linecap="round"/><path d="M10 37v20M0 47h20" stroke-width="5"/></svg>
 				</span>
-				<span class="file-img" tooltip="Add a new note" onclick="//addList()">
+				<span class="file-img" tooltip="Add a new note" onclick="addNote()">
 					<svg viewBox="0 0 47.8 56.9"><path d="M37 2v9h9z" stroke-width="4" stroke-linejoin="round"/><path d="M18 2v37h28V11l-9-9z" stroke-width="4" stroke-linejoin="round"/><path d="M40 17H24M40 24H24M40 30H24" stroke-width="4" stroke-linecap="round"/><path d="M10 37v20M0 47h20" stroke-width="5"/></svg>
 				</span>
 				<span class="file-img" tooltip="Import board" onclick="importBoard()">
@@ -134,11 +144,8 @@ Inspired by Tasker and Tasker2, both by Zevan Rosser (https://github.com/ZevanRo
 				</h1>
 				<input type="text" id="title-text" class="hidden" placeholder="title" />
 			</div>
-			<div id="board">
+			<div id="board" list-counter="0">
 			</div>
-			<info-data>
-				<list-counter>0</list-counter>
-			</info-data>
 		</div>
 	</body>
 </html>

--- a/main.css
+++ b/main.css
@@ -5,7 +5,7 @@ body {
 	background: #555;
 	margin: 0;
 }
-image-src, info-data {
+image-src {
 	display: none;
 }
 svg {
@@ -106,9 +106,11 @@ tr {
 .list-header, .note-header {
 	background: #bbf;
 }
+.name input{
+	height: calc(1em - 4px)
+}
 .name {
-	float: left;
-	margin-left: .33em;
+	padding-left: .33em;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;


### PR DESCRIPTION
## Changes
### Feature
* Upon resizing the window, lists will move alongside the edge if the window gets too small. If the list is not moved after this, they will return to their original position once the window gets bigger. Else, a moved list is given a new position, and will not move when the window gets bigger.
    * Fixes #30 
* Gave function to the "Add Note" button
* All headers and titles are now customizable
    * Finally closed #20
* Exporting a board will no longer always give the default name of "Checklist"
* Default list title changed "List 1" → "List 0"
* Default titles will now appear in textbox upon clicking on them for the first time

### Technical
* Replaced `<info-data>` tags with attributes
    * Closed #26 
* Fine-tuned function `addKeyListener()` to now accept an ID
* Replaced some raw JS with some JQuery